### PR TITLE
fix: disable line in SitNightSky replacing main camera with camera config

### DIFF
--- a/src/sitch/SitNightSky.js
+++ b/src/sitch/SitNightSky.js
@@ -178,7 +178,7 @@ export const SitNightSky = {
 
         addDefaultLights(Sit.brightness)
 
-        setMainCamera(this.mainCamera)
+        //setMainCamera(this.mainCamera)
 
         const lableMainViewPVS = new CNodeViewUI({id: "lableMainViewPVS", overlayView: ViewMan.list.mainView.data});
         lableMainViewPVS.addText("videoLablep1", "L = Lat/Lon from cursor",    10, 2, 1.5, "#f0f00080")


### PR DESCRIPTION
This fixes a crash when loading a nightsky sitch URL, where the `mainCamera` is being overwritten with the `mainCamera` config. I think this line was no longer necessary with the changes introduced in this commit https://github.com/MickWest/sitrec/commit/057b8ca03fe43a82fa2f0c30cc9d8427bc4239ca although I haven't read enough of the codebase to understand the full context yet. I'm not sure if there's also an additional operation required to make use of the mainCamera config defined in the sitch, or if this is already being applied automatically elsewhere.

Below is an example URL that causes a crash without this change, and loads correctly after.

`http://localhost/sitrec/?sitch=nightsky&data=~(olat~51.48~olon~-3.16~lat~39.35449189994994~lon~-87.72930324840814~alt~821.999999999467~startTime~%272024-01-20T02*3a16*3a46.026Z~az~-85.53907759661837~el~6.605151721014493~fov~32~p~(x~-16233969.523814997~y~-272139.51542139146~z~-8550193.84724639)~u~(x~0~y~1~z~0)~q~(x~-0.3932692476076254~y~-0.7470623934145473~z~0.1036948396244999~w~0.5258178957273228)~f~693~pd~false~ssa~true~sfr~false~ssn~false~rehostedFiles~(~%27https*3a*2f*2fwww.metabunk.org*2fsitrec-upload*2f15857*2fstarLink-2024-01-23-db1a18d13015f4cace358ec184808d43.txt)~rhs~true)_`

I believe this is the same bug reported in [this Metabunk post](https://www.metabunk.org/threads/sitrec-is-open-source-on-github-how-you-can-contribute.13323/post-310010).