### PR TITLE
Fixd some build/runtime errors in console mode

### DIFF
--- a/src/MatLines.js
+++ b/src/MatLines.js
@@ -5,7 +5,9 @@ import {Color} from "three";
 var matLines = {} // collection of line materials that need updating on resize
 // we make one entry per unique material
 function makeMatLine(color, linewidth = 2, dashed = false) {
-
+    if(typeof window == 'undefined')
+        return null;
+    
     // if it's not a color object, then make it one
     if (!color.isColor) {
         color = new Color(color);

--- a/src/js/uPlot/uPlot.mick.esm.js
+++ b/src/js/uPlot/uPlot.mick.esm.js
@@ -543,13 +543,14 @@ const LEGEND_MARKER  = pre + "marker";
 const LEGEND_LABEL   = pre + "label";
 const LEGEND_VALUE   = pre + "value";
 
-const doc = document;
-const win = window;
 let pxRatio;
 
 let query;
 
 function setPxRatio() {
+	if(typeof devicePixelRatio == 'undefined')
+		return;
+
 	let _pxRatio = devicePixelRatio;
 
 	// during print preview, Chrome fires off these dppx queries even without changes
@@ -560,7 +561,7 @@ function setPxRatio() {
 		query = matchMedia(`(min-resolution: ${pxRatio - 0.001}dppx) and (max-resolution: ${pxRatio + 0.001}dppx)`);
 		on(change, query, setPxRatio);
 
-		win.dispatchEvent(new CustomEvent(dppxchange));
+		window.dispatchEvent(new CustomEvent(dppxchange));
 	}
 }
 
@@ -581,7 +582,7 @@ function setStylePx(el, name, value) {
 }
 
 function placeTag(tag, cls, targ, refEl) {
-	let el = doc.createElement(tag);
+	let el = document.createElement(tag);
 
 	if (cls != null)
 		addClass(el, cls);
@@ -2397,8 +2398,10 @@ function invalidateRects() {
 	});
 }
 
-on(resize, win, invalidateRects);
-on(scroll, win, invalidateRects, true);
+if(typeof window !== 'undefined') {
+	on(resize, window, invalidateRects);
+	on(scroll, window, invalidateRects, true);
+}
 
 const linearPath = linear() ;
 const pointsPath = points() ;
@@ -4965,7 +4968,7 @@ function uPlot(opts, data, then) {
 		cacheMouse(e, src, _l, _t, _w, _h, _i, true, false);
 
 		if (e != null) {
-			onMouse(mouseup, doc, mouseUp);
+			onMouse(mouseup, document, mouseUp);
 			pubSync(mousedown, self, mouseLeft0, mouseTop0, plotWidCss, plotHgtCss, null);
 		}
 	}
@@ -5030,7 +5033,7 @@ function uPlot(opts, data, then) {
 		}
 
 		if (e != null) {
-			offMouse(mouseup, doc);
+			offMouse(mouseup, document);
 			pubSync(mouseup, self, mouseLeft1, mouseTop1, plotWidCss, plotHgtCss, null);
 		}
 	}
@@ -5098,7 +5101,7 @@ function uPlot(opts, data, then) {
 		_setSize(self.width, self.height, true);
 	}
 
-	on(dppxchange, win, syncPxRatio);
+	on(dppxchange, window, syncPxRatio);
 
 	// internal pub/sub
 	const events = {};
@@ -5176,7 +5179,7 @@ function uPlot(opts, data, then) {
 		sync.unsub(self);
 		cursorPlots.delete(self);
 		mouseListeners.clear();
-		off(dppxchange, win, syncPxRatio);
+		off(dppxchange, window, syncPxRatio);
 		root.remove();
 		fire("destroy");
 	}

--- a/src/nodes/CNodeDisplayCameraFrustum.js
+++ b/src/nodes/CNodeDisplayCameraFrustum.js
@@ -4,7 +4,7 @@ import {Line2} from "../../three.js/examples/jsm/lines/Line2";
 import {CNode3DGroup} from "./CNode3DGroup";
 import {assert} from "../utils"
 import {DebugArrow, DebugArrowAB, dispose, intersectSphere2} from "../threeExt";
-import {guiShowHide, Label3DMan, NodeMan, Sit} from "../Globals";
+import {guiShowHide, NodeMan, Sit} from "../Globals";
 import {makeMatLine} from "../MatLines";
 import {LineSegmentsGeometry} from "../../three.js/examples/jsm/lines/LineSegmentsGeometry";
 import {Ray, Raycaster, Sphere, Vector3} from "three";

--- a/src/nodes/CNodeGUIValue.js
+++ b/src/nodes/CNodeGUIValue.js
@@ -1,6 +1,6 @@
 // a node that lets you choose a value with a slider/input box
 import {assert} from "../utils";
-import {CNodeConstant, NodeMan} from "./CNode";
+import {CNodeConstant} from "./CNode";
 import {par} from "../par";
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -470,7 +470,13 @@ export function closeFullscreen() {
     }
 }
 
-export const versionString = MD5(document.lastModified) // if we want to make version-unique names
+function getVersionString() {
+    if(typeof document !== 'undefined')
+        return MD5(document.lastModified)
+    else
+        return "n/a";
+}
+export const versionString = getVersionString() // if we want to make version-unique names
 
 // difference between two angles, accounting for wrap around and angles <0 and >=360
 export function angleDifferenceDeg(a,b) {


### PR DESCRIPTION
The document/window variables are not defined when building/running the code as a console application. While some of these issues could perhaps be refactored more elegantly, for now just checking whether they're defined allows the code to run successfully.