### PR TITLE
Fix the CI build by reverting to Node.js 22.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     if: true  # the job can be disabled from here
     strategy:
       matrix:   # run a separate jub for all combinations of the following variables
-        node-version: [22]
+        node-version: [22.4]
         # it should typically be enough to build the web app on macOS
         # but allow building it on three platforms if the workflow is triggered manually
         os: ${{ fromJSON(github.event_name != 'workflow_dispatch' && '["macos-latest"]' ||


### PR DESCRIPTION
With the introduction of Node.js 22.5 'npm install' is failing with the error: 'Exit handler never called!'
Based on the reports at https://github.com/npm/cli/issues/7657 the workaround is to revert to 22.4 until it gets fixed.